### PR TITLE
add test openAPI spec for testing

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "",
+    "description": "",
+    "termsOfService": "http://ibm.com",
+    "contact": {
+      "name": "",
+      "url": "http://ibm.com",
+      "email": "jbukuts@ibm.com"
+    },
+    "license": {
+      "name": "",
+      "url": "http://ibm.com"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://jsonplaceholder.typicode.com",
+      "description": ""
+    }
+  ],
+  "paths": {
+    "/todos/{amount}": {
+      "get": {
+        "operationId": "getTodos",
+        "parameters": [
+          {
+            "name": "amount",
+            "in": "path",
+            "description": "amout of todos to return in res",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "test endpoint",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "userId",
+                    "id",
+                    "title",
+                    "completed"
+                  ],
+                  "properties": {
+                    "userId": {
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "completed": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added a simple OpenAPI spec for testing in Watson Assistant. Once our API is finalized we can update and import into WA.

Spec for reference: https://spec.openapis.org/oas/v3.0.3